### PR TITLE
Minor ui changes

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -50,10 +50,10 @@
                                 </div>
 
                                 <div class="col-span-2">
-                                    <div class="relative w-1/3 w-full h-12 h-full px-6 py-4 mt-6 overflow-hidden bg-center bg-cover rounded-lg shadow-sm" style="background-image: url('https://cdn.devdojo.com/images/march2021/wordsmith.jpg')">
+                                    <div class="relative w-full h-full px-6 py-4 mt-6 overflow-hidden bg-center bg-cover rounded-lg shadow-sm" style="background-image: url('https://cdn.devdojo.com/images/march2021/wordsmith.jpg')">
                                         <div class="absolute inset-0 opacity-50 bg-gradient-to-br from-gray-800 to-gray-900"></div>
                                         <div class="relative z-20 flex flex-col items-center justify-center w-full h-full text-gray-100">
-                                            <h2 class="px-4 py-2 text-3xl font-bold font-black text-white border-8 border-white shadow-lg">WORD<span class="font-light">SMITH</span></h2>
+                                            <h2 class="px-4 py-2 text-3xl font-bold text-white border-8 border-white shadow-lg">WORD<span class="font-light">SMITH</span></h2>
                                         </div>
                                     </div>
                                 </div>

--- a/dashboard/posts/create/index.html
+++ b/dashboard/posts/create/index.html
@@ -19,12 +19,12 @@
         <div class="w-full ml-64 bg-gray-100" x-data="{ settings: false, settingsMeta: false }">
             <div class="relative flex justify-start">
                 <div class="max-w-4xl min-h-screen bg-white flex-1 px-10 pl-12 py-8 border-r border-l border-gray-200" id="post">
-                    <input name="title" placeholder="Post Title" class="bg-white border border-gray-300 rounded-lg py-2 block w-full appearance-none leading-normal focus:outline-none focus:shadow-outline text-4xl font-bold text-black mb-4 w-full border-none overflow-visible" id="title" value="">
+                    <input name="title" placeholder="Post Title" class="bg-white border border-gray-300 rounded-lg py-2 block w-full appearance-none leading-normal focus:outline-none focus:shadow-outline text-4xl font-bold text-black mb-4 border-none overflow-visible" id="title" value="">
                     <textarea placeholder="body" class="w-full"></textarea>
                 </div>
 
                 <div class="fixed right-0 top-0 flex bg-white border-l border-b border-gray-300 pb-2 pl-5 rounded-bl-lg">
-                    <div class="inline-block text-gray-500 underline cursor-pointer mr-3 uppercase text-sm flex items-center mt-1" id="save-post">Save</div>
+                    <div class="text-gray-500 underline cursor-pointer mr-3 uppercase text-sm flex items-center mt-1" id="save-post">Save</div>
                     <div @click="settings=true" class="group cursor-pointer rounded-full p-2 bg-gray-200 hover:bg-gray-300 mr-3 mt-2">
                         <svg width="20" height="20" class="fill-current text-gray-500 group-hover:text-gray-600" xmlns="http://www.w3.org/2000/svg">
                             <path d="M19.535 8.427l-2.006-.55c-.296-.696-.422-.992-.697-1.71l1.035-1.816a.607.607 0 00-.106-.76L16.41 2.238a.615.615 0 00-.76-.106l-1.817 1.035c-.697-.296-.992-.422-1.71-.697l-.55-2.006A.653.653 0 0010.961 0H9.039c-.296 0-.549.19-.612.465l-.55 2.006c-.696.296-.992.422-1.71.697L4.35 2.133a.607.607 0 00-.76.106L2.238 3.59a.615.615 0 00-.106.76l1.035 1.817c-.296.697-.422.992-.697 1.71l-2.006.55A.653.653 0 000 9.039v1.922c0 .296.19.549.465.612l2.006.55c.296.696.422.992.697 1.71L2.133 15.65a.607.607 0 00.106.76l1.351 1.352a.615.615 0 00.76.106l1.817-1.035c.697.296.992.422 1.71.697l.55 2.006a.653.653 0 00.612.465h1.922c.296 0 .549-.19.612-.465l.55-2.006c.696-.296.992-.422 1.71-.697l1.816 1.035c.254.148.57.106.76-.106l1.352-1.351a.615.615 0 00.106-.76l-1.035-1.817c.296-.697.422-.992.697-1.71l2.006-.55a.653.653 0 00.465-.612V9.039a.653.653 0 00-.465-.612zM10 14a4 4 0 11-.001-7.999A4 4 0 0110 14z"></path>
@@ -51,17 +51,17 @@
                         class="absolute right-0 top-0 transform bg-gray-100 transition ease-out duration-300 border-l border-gray-200 h-screen overflow-scroll container max-w-md z-40 shadow-2xl flex justify-between flex-col">
                         <div>
                             <h3 class="text-base font-medium text-gray-500 mt-4 ml-6 inline-block">Post Settings</h3>
-                            <div @click="settings=false" class="absolute right-0 top-0 text-4xl font-thin text-gray-500 cursor-pointer cursor-pointer h-12 w-12 leading-none flex justify-center items-center pt-1 pr-3.5">
+                            <div @click="settings=false" class="absolute right-0 top-0 text-4xl font-thin text-gray-500 cursor-pointer h-12 w-12 leading-none flex justify-center items-center pt-1 pr-3.5">
                                 <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
                             </div>
 
                             <div class="p-6">
 
                                 <div class="relative cursor-pointer mb-8 h-56 rounded-lg overflow-hidden">
-                                    <label id="image_preview_upload" class="top-0 left-0 w-full h-56 rounded-lg bg-white border border-gray-200 rounded-lg cursor-pointer block flex flex-col justify-center items-center hidden">
+                                    <label id="image_preview_upload" class="top-0 left-0 w-full h-56 bg-white border border-gray-200 rounded-lg cursor-pointer flex flex-col justify-center items-center">
                                         <span class="px-3 py-2 rounded border border-gray-300 bg-white text-xs font-bold text-gray-600">Upload Post Image</span>
                                     </label>
-                                    <div id="image_preview" class=" w-full h-full">
+                                    <div id="image_preview" class="w-full h-full">
                                         <div id="removeImage" class="w-20 h-6 bg-red-500 text-white absolute right-0 top-0 mr-3 mt-3 rounded-full flex justify-center items-center text-xs leading-none font-bold" onclick="hideImagePreview()">× remove</div>
                                         <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-pixel="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" class="w-full bg-gray-200 rounded-lg h-full" id="image">
                                     </div>
@@ -107,7 +107,7 @@
                             </div>
                         </div>
                         <div class="text-right p-5 flex justify-end" id="delete-post">
-                            <div class="text-red-600 underline text-sm cursor-pointer inline-block flex justify-center items-center" data-slug="test">
+                            <div class="text-red-600 underline text-sm cursor-pointer flex justify-center items-center" data-slug="test">
                                 <svg width="18" height="19" class="fill-current text-red-600" xmlns="http://www.w3.org/2000/svg">
                                     <g>
                                         <path d="M0 6.333c0 .875.733 1.584 1.636 1.584v7.916C1.636 17.583 3.102 19 4.91 19h8.182c1.807 0 3.273-1.418 3.273-3.167V7.917c.903 0 1.636-.71 1.636-1.584V4.75c0-.874-.733-1.583-1.636-1.583H13.09V1.583C13.09.71 12.358 0 11.455 0h-4.91C5.642 0 4.91.709 4.91 1.583v1.584H1.636C.733 3.167 0 3.876 0 4.75v1.583zm14.727 9.5c0 .875-.732 1.584-1.636 1.584H4.909c-.904 0-1.636-.71-1.636-1.584V7.917h11.454v7.916zM6.545 1.583h4.91v1.584h-4.91V1.583zM1.636 4.75h14.728v1.583H1.636V4.75z" fill-rule="nonzero"></path>

--- a/header.html
+++ b/header.html
@@ -1,6 +1,6 @@
 <section class="w-full">
     <a href="#_" class="w-full h-10 bg-gray-900 block">
-        <span class="px-10 mx-auto h-full flex justify-center block lg:max-w-7xl">
+        <span class="px-10 mx-auto h-full flex justify-center lg:max-w-7xl">
             <span class="inline-flex h-full w-auto items-center relative space-x-4 justify-center sm:max-w-xl md:max-w-full">
                 <span class="text-sm font-medium text-white">Latest Update: New Course Released 🎉</span>
                 <span class="text-xs underline font-medium text-gray-200 uppercase sm:block hidden absolute right-0 transform translate-x-full">
@@ -16,12 +16,12 @@
     <div class="py-6 mx-auto px-10 max-w-7xl md:flex-row">
         <div class="flex flex-col flex-wrap items-center md:flex-row">
 
-            <nav class="flex flex-wrap  md:w-2/5 md:ml-auto items-center md:my-0 my-5 order-2 md:order-1 space-x-4 text-xs font-semibold tracking-wide uppercase sm:space-x-6">
+            <nav class="flex flex-wrap md:w-2/5 md:ml-auto items-center md:my-0 my-5 order-2 md:order-1 space-x-4 text-xs font-semibold tracking-wide uppercase sm:space-x-6">
                 <a href="/" class="text-gray-500 hover:text-gray-500">Home</a>
                 <a href="#_" class="text-gray-400 hover:text-gray-500">About</a>
                 <a href="#_" class="text-gray-400 hover:text-gray-500">Projects</a>
             </nav>
-            <a href="/" class="flex items-center text-gray-700 font-medium order-1 md:order-2 text-gray-900 md:w-1/5 md:items-center md:justify-center">
+            <a href="/" class="flex items-center font-medium order-1 md:order-2 text-gray-900 md:w-1/5 md:items-center md:justify-center">
                 <svg class="w-auto h-4 mr-2  fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 202 120"><defs></defs><g fill-rule="evenodd"><path d="M0 0l69.245 120L96 73.633 53.51 0zM64 0l69.244 120L160 73.633 117.51 0zM127 0l37.5 65L202 0z"></path></g></svg>
                 <span class="uppercase text-xs font-bold">Wordsmith</span>
             </a>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
                 <div class="flex flex-col-reverse items-center md:flex-row">
                     <div class="flex flex-col items-start justify-center w-full h-full py-6 md:w-7/12">
                         <div class="flex flex-col items-start justify-center h-full space-y-3 transform md:py-0 py-5 px-8 md:px-10 lg:px-12 md:space-y-5">
-                            <div class="bg-gray-900 flex items-center pl-2 pr-3 py-1.5 mb-3 leading-none rounded-full text-xs font-medium uppercase text-white inline-block">
+                            <div class="bg-gray-900 flex items-center pl-2 pr-3 py-1.5 mb-3 leading-none rounded-full text-xs font-medium uppercase text-white">
                                 <svg class="w-3.5 h-3.5 mr-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path></svg>
                                 <span>Featured</span>
                             </div>


### PR DESCRIPTION
Removed duplicate classes, i.e. 'cursor-pointer' or 'rounded-lg' declared twice on the same element.
Some elements declared multiple _display:_ properties, i.e. flex + block / inline-block / hidden. After some testing, I've defaulted to 'display: flex;'.

Some elements can be optimized for a11y in the future: Images missing alt-tags and form-elements missing labels and/or aria-attributes.